### PR TITLE
Adds id info to bookNotFound log

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/ONSdigital/log.go/log"
@@ -11,9 +12,9 @@ func readFailed(w http.ResponseWriter, err error) {
 	http.Error(w, "cannot read request body", http.StatusInternalServerError)
 }
 
-func bookNotFound(w http.ResponseWriter) {
-	log.Event(nil, "book not found in list", log.INFO)
-	http.Error(w, "book not found", http.StatusNotFound)
+func bookNotFound(w http.ResponseWriter, id string) {
+	log.Event(nil, fmt.Sprintf("book with id=%s not found in list", id), log.INFO)
+	http.Error(w, fmt.Sprintf("book id %q not found", id), http.StatusNotFound)
 }
 
 func unmarshalFailed(w http.ResponseWriter, err error) {

--- a/errors.go
+++ b/errors.go
@@ -13,8 +13,9 @@ func readFailed(w http.ResponseWriter, err error) {
 }
 
 func bookNotFound(w http.ResponseWriter, id string) {
-	log.Event(nil, fmt.Sprintf("book with id=%s not found in list", id), log.INFO)
-	http.Error(w, fmt.Sprintf("book id %q not found", id), http.StatusNotFound)
+	msg := fmt.Sprintf("book id %q not found", id)
+	log.Event(nil, msg, log.INFO)
+	http.Error(w, msg, http.StatusNotFound)
 }
 
 func unmarshalFailed(w http.ResponseWriter, err error) {

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func getBook(w http.ResponseWriter, r *http.Request) {
 
 	book := get(id)
 	if book == nil {
-		bookNotFound(w)
+		bookNotFound(w, id)
 		return
 	}
 
@@ -86,9 +86,10 @@ func getBook(w http.ResponseWriter, r *http.Request) {
 
 func checkoutBook(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	book := get(mux.Vars(r)["id"])
+	id := mux.Vars(r)["id"]
+	book := get(id)
 	if book == nil {
-		bookNotFound(w)
+		bookNotFound(w, id)
 		return
 	}
 
@@ -134,9 +135,10 @@ func checkinBook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	book := get(mux.Vars(r)["id"])
+	id := mux.Vars(r)["id"]
+	book := get(id)
 	if book == nil {
-		bookNotFound(w)
+		bookNotFound(w, id)
 		return
 	}
 


### PR DESCRIPTION
### What
When a book is not found, the id of the book being searched should be logged. 
This PR adds the id info to the bootNotFound log error.

### How to review
Run the app and try to get a book that doesn't exist (`GET http://localhost:8080/library/2`). 
Check that the logged error contains the book id.