### PR TITLE
Replace `fmt` with `errors`

### DIFF
--- a/book.go
+++ b/book.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"time"
 )
@@ -58,12 +59,12 @@ func checkout(b *Book, name string) error {
 	if h != 0 {
 		lastCheckout := b.History[h-1]
 		if lastCheckout.In.IsZero() {
-			return fmt.Errorf("this book is currently checked out to: %s", lastCheckout.Who)
+			return errors.New("this book is currently checked out")
 		}
 	}
 
 	if len(name) == 0 {
-		return fmt.Errorf("a name must be provided for checkout")
+		return errors.New("a name must be provided for checkout")
 	}
 
 	b.History = append(b.History, Checkout{

--- a/book.go
+++ b/book.go
@@ -58,7 +58,7 @@ func checkout(b *Book, name string) error {
 	if h != 0 {
 		lastCheckout := b.History[h-1]
 		if lastCheckout.In.IsZero() {
-			return fmt.Errorf("this book is currently checked out to: [%s]", lastCheckout.Who)
+			return fmt.Errorf("this book is currently checked out to: %s", lastCheckout.Who)
 		}
 	}
 

--- a/book.go
+++ b/book.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"time"
 )
 
@@ -58,12 +57,12 @@ func checkout(b *Book, name string) error {
 	if h != 0 {
 		lastCheckout := b.History[h-1]
 		if lastCheckout.In.IsZero() {
-			return errors.New("this book is currently checked out")
+			return ErrBookCheckedOut
 		}
 	}
 
 	if len(name) == 0 {
-		return errors.New("a name must be provided for checkout")
+		return ErrNameMissing
 	}
 
 	b.History = append(b.History, Checkout{
@@ -77,16 +76,16 @@ func checkout(b *Book, name string) error {
 func checkin(b *Book, review int) error {
 	h := len(b.History)
 	if h == 0 {
-		return errors.New("this book is not currently checked out")
+		return ErrBookNotCheckedOut
 	}
 
 	if review < 1 || review > 5 {
-		return errors.New("a review between 1 and 5 must be provided")
+		return ErrReviewMissing
 	}
 
 	lastCheckout := b.History[h-1]
 	if !lastCheckout.In.IsZero() {
-		return errors.New("this book is not currently checked out")
+		return ErrBookNotCheckedOut
 	}
 
 	b.History[h-1] = Checkout{

--- a/book.go
+++ b/book.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"time"
 )
 
@@ -78,16 +77,16 @@ func checkout(b *Book, name string) error {
 func checkin(b *Book, review int) error {
 	h := len(b.History)
 	if h == 0 {
-		return fmt.Errorf("this book is not currently checked out")
+		return errors.New("this book is not currently checked out")
 	}
 
 	if review < 1 || review > 5 {
-		return fmt.Errorf("a review between 1 and 5 must be provided")
+		return errors.New("a review between 1 and 5 must be provided")
 	}
 
 	lastCheckout := b.History[h-1]
 	if !lastCheckout.In.IsZero() {
-		return fmt.Errorf("this book is not currently checked out")
+		return errors.New("this book is not currently checked out")
 	}
 
 	b.History[h-1] = Checkout{

--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,7 @@ func Get() (*Configuration, error) {
 	}
 
 	cfg = &Configuration{
-		BindAddr: "8080",
+		BindAddr: ":8080",
 	}
 
 	err := envconfig.Process("", cfg)

--- a/config/config.go
+++ b/config/config.go
@@ -1,8 +1,6 @@
 package config
 
-import (
-	"github.com/kelseyhightower/envconfig"
-)
+import "github.com/kelseyhightower/envconfig"
 
 type Configuration struct {
 	BindAddr string `envconfig:"BIND_ADDR"`
@@ -17,8 +15,13 @@ func Get() (*Configuration, error) {
 	}
 
 	cfg = &Configuration{
-		BindAddr: ":8080",
+		BindAddr: "8080",
 	}
 
-	return cfg, envconfig.Process("", cfg)
+	err := envconfig.Process("", cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
 }

--- a/errors.go
+++ b/errors.go
@@ -3,8 +3,15 @@ package main
 import (
 	"fmt"
 	"net/http"
-
+	"errors"
 	"github.com/ONSdigital/log.go/log"
+)
+
+var (
+	ErrBookCheckedOut = errors.New("this book is currently checked out")
+	ErrNameMissing = errors.New("a name must be provided for checkout")
+	ErrReviewMissing = errors.New("a review between 1 and 5 must be provided")
+	ErrBookNotCheckedOut = errors.New("this book is not currently checked out")
 )
 
 func readFailed(w http.ResponseWriter, err error) {

--- a/errors.go
+++ b/errors.go
@@ -1,16 +1,16 @@
 package main
 
 import (
-	"fmt"
-	"net/http"
 	"errors"
+	"fmt"
 	"github.com/ONSdigital/log.go/log"
+	"net/http"
 )
 
 var (
-	ErrBookCheckedOut = errors.New("this book is currently checked out")
-	ErrNameMissing = errors.New("a name must be provided for checkout")
-	ErrReviewMissing = errors.New("a review between 1 and 5 must be provided")
+	ErrBookCheckedOut    = errors.New("this book is currently checked out")
+	ErrNameMissing       = errors.New("a name must be provided for checkout")
+	ErrReviewMissing     = errors.New("a review between 1 and 5 must be provided")
 	ErrBookNotCheckedOut = errors.New("this book is not currently checked out")
 )
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 )
 
-
 func TestErrorMessage(t *testing.T) {
 	Convey("Given a checked out book", t, func() {
 		book := Book{
@@ -16,10 +15,21 @@ func TestErrorMessage(t *testing.T) {
 			user := "otherUser"
 			err := checkout(&book, user)
 
-			Convey("Then an error shows that the book is already checked out", func() {
+			Convey("Then an error message shows that the book is already checked out", func() {
 				So(err, ShouldBeError, "this book is currently checked out")
 			})
 		})
 
 	})
+
+	Convey("Given a book in the book store", t, func() {
+		book := Book{}
+		Convey("When a user tries to check out a book without providing a name", func() {
+			err := checkout(&book, "")
+			Convey("Then an error message shows that a name must be provided", func() {
+				So(err, ShouldBeError, "a name must be provided for checkout")
+			})
+		})
+	})
+
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -12,12 +12,12 @@ func TestErrorMessage(t *testing.T) {
 			History: []Checkout{{Who: "user"}},
 		}
 
-		Convey("When a User checks out the book", func() {
+		Convey("When a User tries checks out the book", func() {
 			user := "otherUser"
 			err := checkout(&book, user)
 
-			Convey("An error should say it's already checked out", func() {
-				So(err, ShouldBeError, "this book is currently checked out to: user")
+			Convey("Then an error shows that the book is already checked out", func() {
+				So(err, ShouldBeError, "this book is currently checked out")
 			})
 		})
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+
+func TestErrorMessage(t *testing.T) {
+	Convey("Given a checked out book", t, func() {
+		book := Book{
+			History: []Checkout{{Who: "user"}},
+		}
+
+		Convey("When a User checks out the book", func() {
+			user := "otherUser"
+			err := checkout(&book, user)
+
+			Convey("An error should say it's already checked out", func() {
+				So(err, ShouldBeError, "this book is currently checked out to: user")
+			})
+		})
+
+	})
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -15,14 +15,14 @@ func TestErrorMessage(t *testing.T) {
 			err := checkout(&book, user)
 
 			Convey("Then an error message shows that the book is already checked out", func() {
-				So(err, ShouldBeError, "this book is currently checked out")
+				So(err, ShouldBeError, ErrBookCheckedOut)
 			})
 		})
 
 		Convey("When a user tries to check in a book without providing a valid review", func() {
 			err := checkin(&book, 100)
 			Convey("Then an error message shows that a review must be provided", func() {
-				So(err, ShouldBeError, "a review between 1 and 5 must be provided")
+				So(err, ShouldBeError, ErrReviewMissing)
 			})
 		})
 
@@ -33,14 +33,14 @@ func TestErrorMessage(t *testing.T) {
 		Convey("When a user tries to check out a book without providing a name", func() {
 			err := checkout(&book, "")
 			Convey("Then an error message shows that a name must be provided", func() {
-				So(err, ShouldBeError, "a name must be provided for checkout")
+				So(err, ShouldBeError, ErrNameMissing)
 			})
 		})
 
 		Convey("When a user tries to check in the book", func() {
 			err := checkin(&book, 4)
 			Convey("Then an error message shows that the book has not been checked out", func() {
-				So(err, ShouldBeError, "this book is not currently checked out")
+				So(err, ShouldBeError, ErrBookNotCheckedOut)
 			})
 		})
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -10,7 +10,6 @@ func TestErrorMessage(t *testing.T) {
 		book := Book{
 			History: []Checkout{{Who: "user"}},
 		}
-
 		Convey("When a User tries checks out the book", func() {
 			user := "otherUser"
 			err := checkout(&book, user)
@@ -20,9 +19,16 @@ func TestErrorMessage(t *testing.T) {
 			})
 		})
 
+		Convey("When a user tries to check in a book without providing a valid review", func() {
+			err := checkin(&book, 100)
+			Convey("Then an error message shows that a review must be provided", func() {
+				So(err, ShouldBeError, "a review between 1 and 5 must be provided")
+			})
+		})
+
 	})
 
-	Convey("Given a book in the book store", t, func() {
+	Convey("Given a book in the book store that has never been checked out", t, func() {
 		book := Book{}
 		Convey("When a user tries to check out a book without providing a name", func() {
 			err := checkout(&book, "")
@@ -30,6 +36,14 @@ func TestErrorMessage(t *testing.T) {
 				So(err, ShouldBeError, "a name must be provided for checkout")
 			})
 		})
+
+		Convey("When a user tries to check in the book", func() {
+			err := checkin(&book, 4)
+			Convey("Then an error message shows that the book has not been checked out", func() {
+				So(err, ShouldBeError, "this book is not currently checked out")
+			})
+		})
+
 	})
 
 }

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/ONSdigital/log.go v1.0.1
 	github.com/gorilla/mux v1.8.0
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/smartystreets/goconvey v1.6.4
 )

--- a/go.sum
+++ b/go.sum
@@ -42,4 +42,5 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190328211700-ab21143f2384 h1:TFlARGu6Czu1z7q93HTxcP1P+/ZFC/IKythI5RzrnRg=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func checkoutBook(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := checkout(book, co.Who); err != nil {
-		log.Event(ctx, "could not check out book", log.ERROR, log.Error(err))
+		log.Event(ctx, "could not check out book", log.ERROR, log.Error(err), log.Data{"book": book.History})
 		http.Error(w, "invalid checkout details provided", http.StatusBadRequest)
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	log.Event(nil, "loaded configuration", log.INFO, log.Data{"config": cfg})
+
 	r := mux.NewRouter()
 
 	r.HandleFunc("/library", createBook).Methods("POST")
@@ -30,7 +32,7 @@ func main() {
 	r.HandleFunc("/library/{id}/checkout", checkoutBook).Methods("PUT")
 	r.HandleFunc("/library/{id}/checkin", checkinBook).Methods("PUT")
 
-	http.ListenAndServe(cfg.BindAddr, r)
+	http.ListenAndServe(":"+cfg.BindAddr, r)
 }
 
 func createBook(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 	r.HandleFunc("/library/{id}/checkout", checkoutBook).Methods("PUT")
 	r.HandleFunc("/library/{id}/checkin", checkinBook).Methods("PUT")
 
-	http.ListenAndServe(":"+cfg.BindAddr, r)
+	http.ListenAndServe(cfg.BindAddr, r)
 }
 
 func createBook(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### This PR:
- Fixes binding address bug (there was an extra `:`)
- Replaces `fmt.Errorf` with `Errors.New`
- Logs config at startup
- Adds goconvey tests

### How to review:
- `goconvey` - check that all tests pass
- Any forgotten `fmt.Errorf`?
I'd love feedback on this attempt at using goconvey 😄 

### Who can review:
Anyone