### PR TITLE
Error message for bad requests

### DIFF
--- a/api/books.go
+++ b/api/books.go
@@ -59,6 +59,11 @@ func checkin(b *models.Book, review int) error {
 func (api *API) createBook(writer http.ResponseWriter, request *http.Request) {
 	ctx := request.Context()
 
+	if request.Body == http.NoBody {
+		missingBody(ctx, writer, ErrRequestBodyMissing)
+		return
+	}
+
 	bytes, err := ioutil.ReadAll(request.Body)
 	defer request.Body.Close()
 	if err != nil {
@@ -91,7 +96,7 @@ func (api *API) createBook(writer http.ResponseWriter, request *http.Request) {
 
 	writer.Header().Set("content-type", "application/json")
 	writer.WriteHeader(http.StatusCreated)
-	writer.Write(bytes)
+	_, _ = writer.Write(bytes)
 }
 
 func (api *API) listBooks(writer http.ResponseWriter, request *http.Request) {
@@ -108,7 +113,7 @@ func (api *API) listBooks(writer http.ResponseWriter, request *http.Request) {
 	}
 
 	writer.Header().Set("Content-Type", "application/json")
-	writer.Write(bytes)
+	_, _ = writer.Write(bytes)
 }
 
 func (api *API) getBook(writer http.ResponseWriter, request *http.Request) {
@@ -129,5 +134,5 @@ func (api *API) getBook(writer http.ResponseWriter, request *http.Request) {
 	}
 
 	writer.Header().Set("Content-Type", "application/json")
-	writer.Write(bytes)
+	_, _ = writer.Write(bytes)
 }

--- a/api/books_test.go
+++ b/api/books_test.go
@@ -37,9 +37,13 @@ func TestEndpoints(t *testing.T) {
 			Convey("Then the HTTP response code is 400", func() {
 				So(response.Code, ShouldEqual, http.StatusBadRequest)
 			})
+
+			Convey("And the response says the request body is missing", func() {
+				So(response.Body.String(), ShouldContainSubstring, ErrRequestBodyMissing.Error())
+			})
 		})
 
-		Convey("When the body does not contain a valid book", func() {
+		Convey("When the body is empty", func() {
 			response := httptest.NewRecorder()
 
 			body := strings.NewReader(`{}`)
@@ -53,6 +57,9 @@ func TestEndpoints(t *testing.T) {
 			})
 			Convey("And there AddBook function is not called", func() {
 				So(len(mockDataStore.AddBookCalls()), ShouldEqual, 0)
+			})
+			Convey("And the response says the request is empty", func() {
+				So(response.Body.String(), ShouldContainSubstring, ErrEmptyRequest.Error())
 			})
 		})
 

--- a/api/books_test.go
+++ b/api/books_test.go
@@ -26,6 +26,19 @@ func TestEndpoints(t *testing.T) {
 
 		api := Setup(ctx, host, mux.NewRouter(), mockDataStore)
 
+		Convey("When there is no request body", func() {
+			response := httptest.NewRecorder()
+
+			body := strings.NewReader(``)
+			request, err := http.NewRequest(http.MethodPost, "/books", body)
+			So(err, ShouldBeNil)
+
+			api.router.ServeHTTP(response, request)
+			Convey("Then the HTTP response code is 400", func() {
+				So(response.Code, ShouldEqual, http.StatusBadRequest)
+			})
+		})
+
 		Convey("When the body does not contain a valid book", func() {
 			response := httptest.NewRecorder()
 

--- a/api/books_test.go
+++ b/api/books_test.go
@@ -56,7 +56,7 @@ func TestEndpoints(t *testing.T) {
 				So(response.Code, ShouldEqual, http.StatusBadRequest)
 			})
 			Convey("And there AddBook function is not called", func() {
-				So(len(mockDataStore.AddBookCalls()), ShouldEqual, 0)
+				So(mockDataStore.AddBookCalls(), ShouldHaveLength, 0)
 			})
 			Convey("And the response says the request is empty", func() {
 				So(response.Body.String(), ShouldContainSubstring, ErrEmptyRequest.Error())
@@ -76,7 +76,7 @@ func TestEndpoints(t *testing.T) {
 				So(response.Code, ShouldEqual, http.StatusCreated)
 			})
 			Convey("And the AddBook function is called once", func() {
-				So(len(mockDataStore.AddBookCalls()), ShouldEqual, 1)
+				So(mockDataStore.AddBookCalls(), ShouldHaveLength, 1)
 			})
 		})
 	})
@@ -104,7 +104,7 @@ func TestEndpoints(t *testing.T) {
 				So(response.Code, ShouldEqual, http.StatusOK)
 			})
 			Convey("And the GetBook function is called once", func() {
-				So(len(mockDataStore.GetBookCalls()), ShouldEqual, 1)
+				So(mockDataStore.GetBookCalls(), ShouldHaveLength, 1)
 			})
 		})
 
@@ -133,7 +133,7 @@ func TestEndpoints(t *testing.T) {
 				So(response.Code, ShouldEqual, http.StatusNotFound)
 			})
 			Convey("And the GetBook function is called once", func() {
-				So(len(mockDataStore.GetBookCalls()), ShouldEqual, 1)
+				So(mockDataStore.GetBookCalls(), ShouldHaveLength, 1)
 			})
 		})
 	})
@@ -160,7 +160,7 @@ func TestEndpoints(t *testing.T) {
 				So(response.Code, ShouldEqual, http.StatusOK)
 			})
 			Convey("And the GetBooks function is called once", func() {
-				So(len(mockDataStore.GetBooksCalls()), ShouldEqual, 1)
+				So(mockDataStore.GetBooksCalls(), ShouldHaveLength, 1)
 			})
 		})
 	})

--- a/api/errors.go
+++ b/api/errors.go
@@ -14,6 +14,7 @@ var (
 	ErrReviewMissing     = errors.New("a review between 1 and 5 must be provided")
 	ErrBookNotCheckedOut = errors.New("this book is not currently checked out")
 	ErrInvalidBook       = errors.New("invalid book. Missing required field")
+	ErrRequestBodyMissing = errors.New("request body missing")
 )
 
 func readFailed(ctx context.Context, w http.ResponseWriter, err error) {
@@ -40,4 +41,9 @@ func marshalFailed(ctx context.Context, w http.ResponseWriter, err error) {
 func invalidBook(ctx context.Context, w http.ResponseWriter, err error) {
 	log.Event(ctx, "invalid book", log.ERROR, log.Error(err))
 	http.Error(w, "invalid book", http.StatusBadRequest)
+}
+
+func missingBody(ctx context.Context, w http.ResponseWriter, err error)  {
+	log.Event(ctx, "invalid book", log.ERROR, log.Error(err))
+	http.Error(w, err.Error(), http.StatusBadRequest)
 }

--- a/api/errors.go
+++ b/api/errors.go
@@ -40,12 +40,12 @@ func marshalFailed(ctx context.Context, w http.ResponseWriter, err error) {
 }
 
 func invalidBook(ctx context.Context, w http.ResponseWriter, err error) {
-	log.Event(ctx, "invalid book", log.ERROR, log.Error(err))
-	http.Error(w, "invalid book", http.StatusBadRequest)
+	log.Event(ctx, ErrInvalidBook.Error(), log.ERROR, log.Error(err))
+	http.Error(w, ErrInvalidBook.Error(), http.StatusBadRequest)
 }
 
 func missingBody(ctx context.Context, w http.ResponseWriter, err error) {
-	log.Event(ctx, "invalid book", log.ERROR, log.Error(err))
+	log.Event(ctx, err.Error(), log.ERROR, log.Error(err))
 	http.Error(w, err.Error(), http.StatusBadRequest)
 }
 

--- a/api/errors.go
+++ b/api/errors.go
@@ -9,12 +9,13 @@ import (
 )
 
 var (
-	ErrBookCheckedOut    = errors.New("this book is currently checked out")
-	ErrNameMissing       = errors.New("a name must be provided for checkout")
-	ErrReviewMissing     = errors.New("a review between 1 and 5 must be provided")
-	ErrBookNotCheckedOut = errors.New("this book is not currently checked out")
-	ErrInvalidBook       = errors.New("invalid book. Missing required field")
+	ErrBookCheckedOut     = errors.New("this book is currently checked out")
+	ErrNameMissing        = errors.New("a name must be provided for checkout")
+	ErrReviewMissing      = errors.New("a review between 1 and 5 must be provided")
+	ErrBookNotCheckedOut  = errors.New("this book is not currently checked out")
+	ErrInvalidBook        = errors.New("invalid book. Missing required field")
 	ErrRequestBodyMissing = errors.New("request body missing")
+	ErrEmptyRequest       = errors.New("empty request body")
 )
 
 func readFailed(ctx context.Context, w http.ResponseWriter, err error) {
@@ -43,7 +44,12 @@ func invalidBook(ctx context.Context, w http.ResponseWriter, err error) {
 	http.Error(w, "invalid book", http.StatusBadRequest)
 }
 
-func missingBody(ctx context.Context, w http.ResponseWriter, err error)  {
+func missingBody(ctx context.Context, w http.ResponseWriter, err error) {
 	log.Event(ctx, "invalid book", log.ERROR, log.Error(err))
+	http.Error(w, err.Error(), http.StatusBadRequest)
+}
+
+func emptyRequest(ctx context.Context, w http.ResponseWriter, err error) {
+	log.Event(ctx, "empty request body", log.ERROR, log.Error(err))
 	http.Error(w, err.Error(), http.StatusBadRequest)
 }


### PR DESCRIPTION
### What
This PR makes sure that when the API provides a helpful error when it receives a POST /books request with an empty body or no body.

### How to review
- `make convey` to check all tests pass
- lines 76-82: is this ok for dealing with empty JSON?
- you could try running the service and POST /books with different request body:
1. nothing
2. `{}`
3. `{"title": "my book"}`

### Who can review
Anyone
