### PR TITLE
Pagination for GET Reviews endpoint

### DIFF
--- a/api/books.go
+++ b/api/books.go
@@ -43,7 +43,7 @@ func (api *API) getBooksHandler(writer http.ResponseWriter, request *http.Reques
 	ctx := request.Context()
 	logData := log.Data{}
 
-	offset, limit, err := api.paginator.SetPaginationValues(request)
+	offset, limit, err := api.paginator.GetPaginationValues(request)
 	logData["offset"] = offset
 	logData["limit"] = limit
 	if err != nil {

--- a/api/books_test.go
+++ b/api/books_test.go
@@ -166,8 +166,8 @@ func TestGetBooksHandler(t *testing.T) {
 			})
 
 			Convey("And the paginator is called to extract the pagination parameters ", func() {
-				So(paginator.SetPaginationValuesCalls(), ShouldHaveLength, 1)
-				So(paginator.SetPaginationValuesCalls()[0].R, ShouldEqual, request)
+				So(paginator.GetPaginationValuesCalls(), ShouldHaveLength, 1)
+				So(paginator.GetPaginationValuesCalls()[0].R, ShouldEqual, request)
 			})
 
 			Convey("And the response contains a count of zero and no book items", func() {
@@ -212,8 +212,8 @@ func TestGetBooksHandler(t *testing.T) {
 			})
 
 			Convey("And the paginator is called to extract the pagination parameters ", func() {
-				So(paginator.SetPaginationValuesCalls(), ShouldHaveLength, 1)
-				So(paginator.SetPaginationValuesCalls()[0].R, ShouldEqual, request)
+				So(paginator.GetPaginationValuesCalls(), ShouldHaveLength, 1)
+				So(paginator.GetPaginationValuesCalls()[0].R, ShouldEqual, request)
 			})
 
 			Convey("And the response contains the paginated response", func() {
@@ -256,8 +256,8 @@ func TestGetBooksHandler(t *testing.T) {
 			})
 
 			Convey("And the paginator is called to extract the pagination parameters ", func() {
-				So(paginator.SetPaginationValuesCalls(), ShouldHaveLength, 1)
-				So(paginator.SetPaginationValuesCalls()[0].R, ShouldEqual, request)
+				So(paginator.GetPaginationValuesCalls(), ShouldHaveLength, 1)
+				So(paginator.GetPaginationValuesCalls()[0].R, ShouldEqual, request)
 			})
 
 			Convey("And a 500 InternalServerError status code is returned", func() {
@@ -340,7 +340,7 @@ func TestAddBookHandler(t *testing.T) {
 
 func mockPaginator() *mock.PaginatorMock {
 	paginator := &mock.PaginatorMock{
-		SetPaginationValuesFunc: func(r *http.Request) (int, int, error) {
+		GetPaginationValuesFunc: func(r *http.Request) (int, int, error) {
 			return offset, limit, nil
 		},
 	}

--- a/api/reviews.go
+++ b/api/reviews.go
@@ -83,7 +83,6 @@ func (api *API) getReviewsHandler(writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	//reviews.Count = len(reviews.Items)
 	response := models.ReviewsResponse{
 		Items: reviews,
 		Page: pagination.Page{

--- a/api/reviews.go
+++ b/api/reviews.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ONSdigital/log.go/log"
 	"github.com/cadmiumcat/books-api/apierrors"
 	"github.com/cadmiumcat/books-api/models"
+	"github.com/cadmiumcat/books-api/pagination"
 	"github.com/gorilla/mux"
 	"net/http"
 )
@@ -61,27 +62,39 @@ func (api *API) getReviewsHandler(writer http.ResponseWriter, request *http.Requ
 
 	logData := log.Data{"book_id": bookID}
 
+	offset, limit, err := api.paginator.SetPaginationValues(request)
+	logData["offset"] = offset
+	logData["limit"] = limit
 	if bookID == "" {
 		handleError(ctx, writer, apierrors.ErrEmptyBookID, logData)
 		return
 	}
 
 	// Confirm that book exists. If bookID not found, then do not check for the reviews
-	_, err := api.dataStore.GetBook(ctx, bookID)
+	_, err = api.dataStore.GetBook(ctx, bookID)
 	if err != nil {
 		handleError(ctx, writer, err, logData)
 		return
 	}
 
-	reviews, err := api.dataStore.GetReviews(ctx, bookID)
+	reviews, totalCount, err := api.dataStore.GetReviews(ctx, bookID, offset, limit)
 	if err != nil {
 		handleError(ctx, writer, err, logData)
 		return
 	}
 
-	reviews.Count = len(reviews.Items)
+	//reviews.Count = len(reviews.Items)
+	response := models.ReviewsResponse{
+		Items: reviews,
+		Page: pagination.Page{
+			Count:      len(reviews),
+			Offset:     offset,
+			Limit:      limit,
+			TotalCount: totalCount,
+		},
+	}
 
-	if err := WriteJSONBody(reviews, writer, http.StatusOK); err != nil {
+	if err := WriteJSONBody(response, writer, http.StatusOK); err != nil {
 		handleError(ctx, writer, err, logData)
 		return
 	}

--- a/api/reviews.go
+++ b/api/reviews.go
@@ -62,7 +62,7 @@ func (api *API) getReviewsHandler(writer http.ResponseWriter, request *http.Requ
 
 	logData := log.Data{"book_id": bookID}
 
-	offset, limit, err := api.paginator.SetPaginationValues(request)
+	offset, limit, err := api.paginator.GetPaginationValues(request)
 	logData["offset"] = offset
 	logData["limit"] = limit
 	if bookID == "" {

--- a/api/reviews_test.go
+++ b/api/reviews_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cadmiumcat/books-api/interfaces/mock"
 	"github.com/cadmiumcat/books-api/models"
 	"github.com/cadmiumcat/books-api/mongo"
+	"github.com/cadmiumcat/books-api/pagination"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	. "github.com/smartystreets/goconvey/convey"
@@ -327,15 +328,28 @@ func TestGetReviewsHandler(t *testing.T) {
 			Convey("Then the HTTP response code is 200", func() {
 				So(response.Code, ShouldEqual, http.StatusOK)
 			})
-			Convey("And the GetReviews function is called once", func() {
+			Convey("And the GetReviews function is called once, and the pagination parameters passed to it", func() {
 				So(mockDataStore.GetReviewsCalls(), ShouldHaveLength, 1)
+				So(mockDataStore.GetReviewsCalls()[0].Limit, ShouldEqual, limit)
+				So(mockDataStore.GetReviewsCalls()[0].Offset, ShouldEqual, offset)
+			})
+			Convey("And the paginator is called to extract the pagination parameters ", func() {
+				So(paginator.SetPaginationValuesCalls(), ShouldHaveLength, 1)
+				So(paginator.SetPaginationValuesCalls()[0].R, ShouldEqual, request)
 			})
 			Convey("And the response body contains the right number of reviews", func() {
 				payload, err := ioutil.ReadAll(response.Body)
 				So(err, ShouldBeNil)
-				reviews := models.ReviewsResponse{}
-				err = json.Unmarshal(payload, &reviews)
-				So(reviews.Count, ShouldEqual, 2)
+				page := models.ReviewsResponse{}
+				err = json.Unmarshal(payload, &page)
+				So(err, ShouldBeNil)
+				expectedPage := pagination.Page{Count: 2, Offset: offset, Limit: limit, TotalCount: 2}
+
+				So(page.TotalCount, ShouldEqual, expectedPage.TotalCount)
+				So(page.Count, ShouldEqual, len(page.Items))
+				So(page.Offset, ShouldEqual, offset)
+				So(page.Limit, ShouldEqual, limit)
+				So(page.Page, ShouldResemble, expectedPage)
 			})
 		})
 	})
@@ -364,17 +378,29 @@ func TestGetReviewsHandler(t *testing.T) {
 			Convey("Then the HTTP response code is 200", func() {
 				So(response.Code, ShouldEqual, http.StatusOK)
 			})
-			Convey("And the GetReviews function is called once", func() {
+			Convey("And the GetReviews function is called once, and the pagination parameters passed to it", func() {
 				So(mockDataStore.GetBookCalls(), ShouldHaveLength, 1)
 				So(mockDataStore.GetReviewsCalls(), ShouldHaveLength, 1)
+				So(mockDataStore.GetReviewsCalls()[0].Limit, ShouldEqual, limit)
+				So(mockDataStore.GetReviewsCalls()[0].Offset, ShouldEqual, offset)
+			})
+			Convey("And the paginator is called to extract the pagination parameters ", func() {
+				So(paginator.SetPaginationValuesCalls(), ShouldHaveLength, 1)
+				So(paginator.SetPaginationValuesCalls()[0].R, ShouldEqual, request)
 			})
 			Convey("And the response contains a count of zero and no review items", func() {
 				payload, err := ioutil.ReadAll(response.Body)
 				So(err, ShouldBeNil)
-				reviews := models.ReviewsResponse{}
-				err = json.Unmarshal(payload, &reviews)
-				So(reviews.Count, ShouldEqual, 0)
-				So(reviews.Items, ShouldHaveLength, 0)
+				page := models.ReviewsResponse{}
+				err = json.Unmarshal(payload, &page)
+				So(err, ShouldBeNil)
+				expectedPage := pagination.Page{Count: 0, Offset: offset, Limit: limit, TotalCount: 0}
+
+				So(page.TotalCount, ShouldEqual, expectedPage.TotalCount)
+				So(page.Count, ShouldEqual, len(page.Items))
+				So(page.Offset, ShouldEqual, offset)
+				So(page.Limit, ShouldEqual, limit)
+				So(page.Page, ShouldResemble, expectedPage)
 			})
 		})
 	})
@@ -437,6 +463,12 @@ func TestGetReviewsHandler(t *testing.T) {
 			Convey("And the GetBook and GetReviews functions are called", func() {
 				So(mockDataStore.GetBookCalls(), ShouldHaveLength, 1)
 				So(mockDataStore.GetReviewsCalls(), ShouldHaveLength, 1)
+				So(mockDataStore.GetReviewsCalls()[0].Limit, ShouldEqual, limit)
+				So(mockDataStore.GetReviewsCalls()[0].Offset, ShouldEqual, offset)
+			})
+			Convey("And the paginator is called to extract the pagination parameters ", func() {
+				So(paginator.SetPaginationValuesCalls(), ShouldHaveLength, 1)
+				So(paginator.SetPaginationValuesCalls()[0].R, ShouldEqual, request)
 			})
 		})
 

--- a/api/reviews_test.go
+++ b/api/reviews_test.go
@@ -334,8 +334,8 @@ func TestGetReviewsHandler(t *testing.T) {
 				So(mockDataStore.GetReviewsCalls()[0].Offset, ShouldEqual, offset)
 			})
 			Convey("And the paginator is called to extract the pagination parameters ", func() {
-				So(paginator.SetPaginationValuesCalls(), ShouldHaveLength, 1)
-				So(paginator.SetPaginationValuesCalls()[0].R, ShouldEqual, request)
+				So(paginator.GetPaginationValuesCalls(), ShouldHaveLength, 1)
+				So(paginator.GetPaginationValuesCalls()[0].R, ShouldEqual, request)
 			})
 			Convey("And the response body contains the right number of reviews", func() {
 				payload, err := ioutil.ReadAll(response.Body)
@@ -385,8 +385,8 @@ func TestGetReviewsHandler(t *testing.T) {
 				So(mockDataStore.GetReviewsCalls()[0].Offset, ShouldEqual, offset)
 			})
 			Convey("And the paginator is called to extract the pagination parameters ", func() {
-				So(paginator.SetPaginationValuesCalls(), ShouldHaveLength, 1)
-				So(paginator.SetPaginationValuesCalls()[0].R, ShouldEqual, request)
+				So(paginator.GetPaginationValuesCalls(), ShouldHaveLength, 1)
+				So(paginator.GetPaginationValuesCalls()[0].R, ShouldEqual, request)
 			})
 			Convey("And the response contains a count of zero and no review items", func() {
 				payload, err := ioutil.ReadAll(response.Body)
@@ -467,8 +467,8 @@ func TestGetReviewsHandler(t *testing.T) {
 				So(mockDataStore.GetReviewsCalls()[0].Offset, ShouldEqual, offset)
 			})
 			Convey("And the paginator is called to extract the pagination parameters ", func() {
-				So(paginator.SetPaginationValuesCalls(), ShouldHaveLength, 1)
-				So(paginator.SetPaginationValuesCalls()[0].R, ShouldEqual, request)
+				So(paginator.GetPaginationValuesCalls(), ShouldHaveLength, 1)
+				So(paginator.GetPaginationValuesCalls()[0].R, ShouldEqual, request)
 			})
 		})
 

--- a/interfaces/interfaces.go
+++ b/interfaces/interfaces.go
@@ -16,7 +16,7 @@ import (
 
 // Paginator defines the required methods from the paginator package
 type Paginator interface {
-	SetPaginationValues(r *http.Request) (offset int, limit int, err error)
+	GetPaginationValues(r *http.Request) (offset int, limit int, err error)
 }
 
 // DataStore implements the methods required to interact with the database

--- a/interfaces/interfaces.go
+++ b/interfaces/interfaces.go
@@ -27,7 +27,7 @@ type DataStore interface {
 	GetBook(ctx context.Context, id string) (*models.Book, error)
 	GetBooks(ctx context.Context, offset, limit int) ([]models.Book, int, error)
 	GetReview(ctx context.Context, reviewID string) (*models.Review, error)
-	GetReviews(ctx context.Context, bookID string) (models.Reviews, error)
+	GetReviews(ctx context.Context, bookID string, offset, limit int) ([]models.Review, int, error)
 	AddReview(ctx context.Context, review *models.Review) (err error)
 	UpdateReview(ctx context.Context, reviewID string, review *models.Review) (err error)
 }

--- a/interfaces/mock/datastore.go
+++ b/interfaces/mock/datastore.go
@@ -39,7 +39,7 @@ var _ interfaces.DataStore = &DataStoreMock{}
 //             GetReviewFunc: func(ctx context.Context, reviewID string) (*models.Review, error) {
 // 	               panic("mock out the GetReview method")
 //             },
-//             GetReviewsFunc: func(ctx context.Context, bookID string, offset int, limit int) ([]models.Review, error) {
+//             GetReviewsFunc: func(ctx context.Context, bookID string, offset int, limit int) ([]models.Review, int, error) {
 // 	               panic("mock out the GetReviews method")
 //             },
 //             InitFunc: func(in1 config.MongoConfig) error {
@@ -74,7 +74,7 @@ type DataStoreMock struct {
 	GetReviewFunc func(ctx context.Context, reviewID string) (*models.Review, error)
 
 	// GetReviewsFunc mocks the GetReviews method.
-	GetReviewsFunc func(ctx context.Context, bookID string, offset int, limit int) ([]models.Review, error)
+	GetReviewsFunc func(ctx context.Context, bookID string, offset int, limit int) ([]models.Review, int, error)
 
 	// InitFunc mocks the Init method.
 	InitFunc func(in1 config.MongoConfig) error
@@ -374,7 +374,7 @@ func (mock *DataStoreMock) GetReviewCalls() []struct {
 }
 
 // GetReviews calls GetReviewsFunc.
-func (mock *DataStoreMock) GetReviews(ctx context.Context, bookID string, offset int, limit int) ([]models.Review, error) {
+func (mock *DataStoreMock) GetReviews(ctx context.Context, bookID string, offset int, limit int) ([]models.Review, int, error) {
 	if mock.GetReviewsFunc == nil {
 		panic("DataStoreMock.GetReviewsFunc: method is nil but DataStore.GetReviews was just called")
 	}

--- a/interfaces/mock/datastore.go
+++ b/interfaces/mock/datastore.go
@@ -39,7 +39,7 @@ var _ interfaces.DataStore = &DataStoreMock{}
 //             GetReviewFunc: func(ctx context.Context, reviewID string) (*models.Review, error) {
 // 	               panic("mock out the GetReview method")
 //             },
-//             GetReviewsFunc: func(ctx context.Context, bookID string) (models.Reviews, error) {
+//             GetReviewsFunc: func(ctx context.Context, bookID string, offset int, limit int) ([]models.Review, error) {
 // 	               panic("mock out the GetReviews method")
 //             },
 //             InitFunc: func(in1 config.MongoConfig) error {
@@ -74,7 +74,7 @@ type DataStoreMock struct {
 	GetReviewFunc func(ctx context.Context, reviewID string) (*models.Review, error)
 
 	// GetReviewsFunc mocks the GetReviews method.
-	GetReviewsFunc func(ctx context.Context, bookID string) (models.Reviews, error)
+	GetReviewsFunc func(ctx context.Context, bookID string, offset int, limit int) ([]models.Review, error)
 
 	// InitFunc mocks the Init method.
 	InitFunc func(in1 config.MongoConfig) error
@@ -132,6 +132,10 @@ type DataStoreMock struct {
 			Ctx context.Context
 			// BookID is the bookID argument value.
 			BookID string
+			// Offset is the offset argument value.
+			Offset int
+			// Limit is the limit argument value.
+			Limit int
 		}
 		// Init holds details about calls to the Init method.
 		Init []struct {
@@ -370,21 +374,25 @@ func (mock *DataStoreMock) GetReviewCalls() []struct {
 }
 
 // GetReviews calls GetReviewsFunc.
-func (mock *DataStoreMock) GetReviews(ctx context.Context, bookID string) (models.Reviews, error) {
+func (mock *DataStoreMock) GetReviews(ctx context.Context, bookID string, offset int, limit int) ([]models.Review, error) {
 	if mock.GetReviewsFunc == nil {
 		panic("DataStoreMock.GetReviewsFunc: method is nil but DataStore.GetReviews was just called")
 	}
 	callInfo := struct {
 		Ctx    context.Context
 		BookID string
+		Offset int
+		Limit  int
 	}{
 		Ctx:    ctx,
 		BookID: bookID,
+		Offset: offset,
+		Limit:  limit,
 	}
 	mock.lockGetReviews.Lock()
 	mock.calls.GetReviews = append(mock.calls.GetReviews, callInfo)
 	mock.lockGetReviews.Unlock()
-	return mock.GetReviewsFunc(ctx, bookID)
+	return mock.GetReviewsFunc(ctx, bookID, offset, limit)
 }
 
 // GetReviewsCalls gets all the calls that were made to GetReviews.
@@ -393,10 +401,14 @@ func (mock *DataStoreMock) GetReviews(ctx context.Context, bookID string) (model
 func (mock *DataStoreMock) GetReviewsCalls() []struct {
 	Ctx    context.Context
 	BookID string
+	Offset int
+	Limit  int
 } {
 	var calls []struct {
 		Ctx    context.Context
 		BookID string
+		Offset int
+		Limit  int
 	}
 	mock.lockGetReviews.RLock()
 	calls = mock.calls.GetReviews

--- a/interfaces/mock/paginator.go
+++ b/interfaces/mock/paginator.go
@@ -19,8 +19,8 @@ var _ interfaces.Paginator = &PaginatorMock{}
 //
 //         // make and configure a mocked interfaces.Paginator
 //         mockedPaginator := &PaginatorMock{
-//             SetPaginationValuesFunc: func(r *http.Request) (int, int, error) {
-// 	               panic("mock out the SetPaginationValues method")
+//             GetPaginationValuesFunc: func(r *http.Request) (int, int, error) {
+// 	               panic("mock out the GetPaginationValues method")
 //             },
 //         }
 //
@@ -29,47 +29,47 @@ var _ interfaces.Paginator = &PaginatorMock{}
 //
 //     }
 type PaginatorMock struct {
-	// SetPaginationValuesFunc mocks the SetPaginationValues method.
-	SetPaginationValuesFunc func(r *http.Request) (int, int, error)
+	// GetPaginationValuesFunc mocks the GetPaginationValues method.
+	GetPaginationValuesFunc func(r *http.Request) (int, int, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
-		// SetPaginationValues holds details about calls to the SetPaginationValues method.
-		SetPaginationValues []struct {
+		// GetPaginationValues holds details about calls to the GetPaginationValues method.
+		GetPaginationValues []struct {
 			// R is the r argument value.
 			R *http.Request
 		}
 	}
-	lockSetPaginationValues sync.RWMutex
+	lockGetPaginationValues sync.RWMutex
 }
 
-// SetPaginationValues calls SetPaginationValuesFunc.
-func (mock *PaginatorMock) SetPaginationValues(r *http.Request) (int, int, error) {
-	if mock.SetPaginationValuesFunc == nil {
-		panic("PaginatorMock.SetPaginationValuesFunc: method is nil but Paginator.SetPaginationValues was just called")
+// GetPaginationValues calls GetPaginationValuesFunc.
+func (mock *PaginatorMock) GetPaginationValues(r *http.Request) (int, int, error) {
+	if mock.GetPaginationValuesFunc == nil {
+		panic("PaginatorMock.GetPaginationValuesFunc: method is nil but Paginator.GetPaginationValues was just called")
 	}
 	callInfo := struct {
 		R *http.Request
 	}{
 		R: r,
 	}
-	mock.lockSetPaginationValues.Lock()
-	mock.calls.SetPaginationValues = append(mock.calls.SetPaginationValues, callInfo)
-	mock.lockSetPaginationValues.Unlock()
-	return mock.SetPaginationValuesFunc(r)
+	mock.lockGetPaginationValues.Lock()
+	mock.calls.GetPaginationValues = append(mock.calls.GetPaginationValues, callInfo)
+	mock.lockGetPaginationValues.Unlock()
+	return mock.GetPaginationValuesFunc(r)
 }
 
-// SetPaginationValuesCalls gets all the calls that were made to SetPaginationValues.
+// GetPaginationValuesCalls gets all the calls that were made to GetPaginationValues.
 // Check the length with:
-//     len(mockedPaginator.SetPaginationValuesCalls())
-func (mock *PaginatorMock) SetPaginationValuesCalls() []struct {
+//     len(mockedPaginator.GetPaginationValuesCalls())
+func (mock *PaginatorMock) GetPaginationValuesCalls() []struct {
 	R *http.Request
 } {
 	var calls []struct {
 		R *http.Request
 	}
-	mock.lockSetPaginationValues.RLock()
-	calls = mock.calls.SetPaginationValues
-	mock.lockSetPaginationValues.RUnlock()
+	mock.lockGetPaginationValues.RLock()
+	calls = mock.calls.GetPaginationValues
+	mock.lockGetPaginationValues.RUnlock()
 	return calls
 }

--- a/models/review.go
+++ b/models/review.go
@@ -3,6 +3,7 @@ package models
 import (
 	"fmt"
 	"github.com/cadmiumcat/books-api/apierrors"
+	"github.com/cadmiumcat/books-api/pagination"
 	uuid "github.com/satori/go.uuid"
 	"time"
 )
@@ -21,12 +22,6 @@ type Review struct {
 type ReviewLink struct {
 	Self string `json:"self" bson:"self"`
 	Book string `json:"book" bson:"book"`
-}
-
-// Reviews contains all the items (Review) in the library and a total count of those items
-type Reviews struct {
-	Count int      `json:"totalCount"`
-	Items []Review `json:"items"`
 }
 
 func (r Review) Validate() error {
@@ -48,6 +43,12 @@ func (r Review) Validate() error {
 type User struct {
 	Forenames string `json:"forenames,omitempty" bson:"forenames,omitempty"`
 	Surname   string `json:"surname,omitempty" bson:"surname,omitempty"`
+}
+
+// ReviewsResponse represents a paginated list of Books
+type ReviewsResponse struct {
+	Items []Review `json:"items"`
+	pagination.Page
 }
 
 // NewReview returns a Review structure based on a bookID

--- a/pagination/pagination.go
+++ b/pagination/pagination.go
@@ -40,9 +40,9 @@ type Page struct {
 	TotalCount int `json:"total_count"`
 }
 
-// SetPaginationValues returns pagination parameters based on a request, or the default values if the request does not specify them.
+// GetPaginationValues returns pagination parameters based on a request, or the default values if the request does not specify them.
 // It returns an error if the parameters are not valid
-func (p *Paginator) SetPaginationValues(r *http.Request) (offset int, limit int, err error) {
+func (p *Paginator) GetPaginationValues(r *http.Request) (offset int, limit int, err error) {
 	offsetParameter := r.URL.Query().Get("offset")
 	limitParameter := r.URL.Query().Get("limit")
 

--- a/pagination/pagination_test.go
+++ b/pagination/pagination_test.go
@@ -17,9 +17,9 @@ func TestReadPaginationValues(t *testing.T) {
 
 	Convey("Given a request without pagination parameters", t, func() {
 		r := httptest.NewRequest("GET", "/endpoint_to_paginate", nil)
-		Convey("When SetPaginationValues is called", func() {
+		Convey("When GetPaginationValues is called", func() {
 
-			offset, limit, err := defaultPaginator.SetPaginationValues(r)
+			offset, limit, err := defaultPaginator.GetPaginationValues(r)
 			Convey("Then the default values are returned", func() {
 				So(err, ShouldBeNil)
 				So(limit, ShouldEqual, defaultLimit)
@@ -30,8 +30,8 @@ func TestReadPaginationValues(t *testing.T) {
 
 	Convey("Given a request with valid pagination parameters", t, func() {
 		r := httptest.NewRequest("GET", "/endpoint_to_paginate?limit=13&offset=2", nil)
-		Convey("When SetPaginationValues is called", func() {
-			offset, limit, err := defaultPaginator.SetPaginationValues(r)
+		Convey("When GetPaginationValues is called", func() {
+			offset, limit, err := defaultPaginator.GetPaginationValues(r)
 			Convey("Then the default values are overwritten by the ones in the request", func() {
 				So(err, ShouldBeNil)
 				So(limit, ShouldEqual, 13)
@@ -42,8 +42,8 @@ func TestReadPaginationValues(t *testing.T) {
 
 	Convey("Given a request with a negative limit value", t, func() {
 		r := httptest.NewRequest("GET", "/endpoint_to_paginate?limit=-13&offset=2", nil)
-		Convey("When SetPaginationValues is called", func() {
-			offset, limit, err := defaultPaginator.SetPaginationValues(r)
+		Convey("When GetPaginationValues is called", func() {
+			offset, limit, err := defaultPaginator.GetPaginationValues(r)
 			Convey("Then the an error is returned saying the limit value is invalid", func() {
 				So(err, ShouldBeError)
 				So(err, ShouldEqual, ErrInvalidLimitParameter)
@@ -55,8 +55,8 @@ func TestReadPaginationValues(t *testing.T) {
 
 	Convey("Given a request with a non-numerical limit value", t, func() {
 		r := httptest.NewRequest("GET", "/endpoint_to_paginate?limit=two&offset=2", nil)
-		Convey("When SetPaginationValues is called", func() {
-			offset, limit, err := defaultPaginator.SetPaginationValues(r)
+		Convey("When GetPaginationValues is called", func() {
+			offset, limit, err := defaultPaginator.GetPaginationValues(r)
 			Convey("Then the an error is returned saying the limit value is invalid", func() {
 				So(err, ShouldBeError)
 				So(err, ShouldEqual, ErrInvalidLimitParameter)
@@ -68,8 +68,8 @@ func TestReadPaginationValues(t *testing.T) {
 
 	Convey("Given a request with a negative offset value", t, func() {
 		r := httptest.NewRequest("GET", "/endpoint_to_paginate?limit=13&offset=-2", nil)
-		Convey("When SetPaginationValues is called", func() {
-			offset, limit, err := defaultPaginator.SetPaginationValues(r)
+		Convey("When GetPaginationValues is called", func() {
+			offset, limit, err := defaultPaginator.GetPaginationValues(r)
 			Convey("Then the an error is returned saying the offset value is invalid", func() {
 				So(err, ShouldBeError)
 				So(err, ShouldEqual, ErrInvalidOffsetParameter)
@@ -81,8 +81,8 @@ func TestReadPaginationValues(t *testing.T) {
 
 	Convey("Given a request with a non-numerical offset value", t, func() {
 		r := httptest.NewRequest("GET", "/endpoint_to_paginate?limit=13&offset=two", nil)
-		Convey("When SetPaginationValues is called", func() {
-			offset, limit, err := defaultPaginator.SetPaginationValues(r)
+		Convey("When GetPaginationValues is called", func() {
+			offset, limit, err := defaultPaginator.GetPaginationValues(r)
 			Convey("Then the an error is returned saying the offset value is invalid", func() {
 				So(err, ShouldBeError)
 				So(err, ShouldEqual, ErrInvalidOffsetParameter)
@@ -94,8 +94,8 @@ func TestReadPaginationValues(t *testing.T) {
 
 	Convey("Given a request with a limit value that exceeds the default maximum limit", t, func() {
 		r := httptest.NewRequest("GET", "/endpoint_to_paginate?limit=101&offset=2", nil)
-		Convey("When SetPaginationValues is called", func() {
-			offset, limit, err := defaultPaginator.SetPaginationValues(r)
+		Convey("When GetPaginationValues is called", func() {
+			offset, limit, err := defaultPaginator.GetPaginationValues(r)
 			Convey("Then the an error is returned saying the limit value is invalid and is over the maximum value", func() {
 				So(err, ShouldBeError)
 				So(err, ShouldEqual, ErrLimitOverMax)


### PR DESCRIPTION
This PR adds pagination to the GET /books/{book_id}/reviews endpoint.

### How to review?

Check that tests pass make convey and that the code changes make sense.

To try it out:
- Run the service and add some books and reviews (I like to use postman to make this easier)
- GET /books/{book_id}/reviews with various values for limit and offset to make sure they make sense, and the correct error responses are provided (e.g. invalid query parameter: offset when offset=-1)

### Who can review?

Anyone